### PR TITLE
Message Formatting(MiniMessage)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,16 @@
 			<version>2.2.1</version>
 			<scope>compile</scope>
 		</dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.22.0</version>
+        </dependency>
+    <dependency>
+        <groupId>net.kyori</groupId>
+        <artifactId>adventure-platform-bukkit</artifactId>
+        <version>4.4.0</version>
+    </dependency>
 	</dependencies>
 	
 	<build>

--- a/src/main/java/sleeper/main/Commands.java
+++ b/src/main/java/sleeper/main/Commands.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Player;
 
 public class Commands implements CommandExecutor {
     Main plugin;
+    MessageFormatting messageFormatting;
     Voting voting;
 
     String msgPlayerNotFound = "&c%player% not found.";
@@ -27,10 +28,11 @@ public class Commands implements CommandExecutor {
     String msgOnlyPlayers = "&cThis command can only be run by players.";
     String sleepHelpList = "&cInvalid command, valid subcommands are: ";
     
-    public Commands(Main plugin, Voting voting) {
+    public Commands(Main plugin, Voting voting, MessageFormatting messageFormatting) {
         super();
         this.plugin = plugin;
         this.voting = voting;
+        this.messageFormatting = messageFormatting;
     }
 
     @Override
@@ -38,7 +40,7 @@ public class Commands implements CommandExecutor {
         switch (cmd.getName().toLowerCase()) {
         case "sleep":
             if (args.length < 1) {
-                sender.sendMessage(ChatColor.translateAlternateColorCodes('&', playerHelpMsg(sender)));
+                sender.sendMessage(messageFormatting.parseMessage(playerHelpMsg(sender)));
                 break;
             }
             // Console compatible commands
@@ -49,23 +51,23 @@ public class Commands implements CommandExecutor {
             		if (!isPlayer(sender)) return true;
             		UUID uuid = ((Player) sender).getUniqueId();
 	                if (plugin.ignorePlayers.contains(uuid)) {
-	                    sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgSelfIgnoreOff));
+	                    sender.sendMessage(messageFormatting.parseMessage(msgSelfIgnoreOff));
 	                    plugin.ignorePlayers.remove(uuid);
 	                } else {
-	                    sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgSelfIgnoreOn));
+	                    sender.sendMessage(messageFormatting.parseMessage(msgSelfIgnoreOn));
 	                    plugin.ignorePlayers.add(uuid);
 	                }
             	} else if (args.length < 3) { // Another player
             		String targetName = args[1];
             		Player target = Bukkit.getPlayer(targetName);
             		if (target == null) {
-            			sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgPlayerNotFound.replaceAll("%player%", targetName)));
+            			sender.sendMessage(messageFormatting.parseMessage(msgPlayerNotFound.replaceAll("%player%", targetName)));
             		} else {
             			if (plugin.ignorePlayers.contains(target.getUniqueId())) {
-            				sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgOtherIgnoreOff.replaceAll("%player%", target.getName())));
+            				sender.sendMessage(messageFormatting.parseMessage(msgOtherIgnoreOff.replaceAll("%player%", target.getName())));
     	                    plugin.ignorePlayers.remove(target.getUniqueId());
     	                } else {
-    	                	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgOtherIgnoreOn.replaceAll("%player%", target.getName())));
+    	                	sender.sendMessage(messageFormatting.parseMessage(msgOtherIgnoreOn.replaceAll("%player%", target.getName())));
     	                    plugin.ignorePlayers.add(target.getUniqueId());
     	                }
             		}
@@ -74,19 +76,19 @@ public class Commands implements CommandExecutor {
             		String stateString = args[2].toUpperCase();
             		Player target = Bukkit.getPlayer(targetName);
             		if (target == null) {
-            			sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgPlayerNotFound.replaceAll("%player%", targetName)));
+            			sender.sendMessage(messageFormatting.parseMessage(msgPlayerNotFound.replaceAll("%player%", targetName)));
             		} else if (!stateString.equals("TRUE") && !stateString.equals("FALSE")) {
-            			sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgInvalidState.replaceAll("%input%", stateString)));
+            			sender.sendMessage(messageFormatting.parseMessage(msgInvalidState.replaceAll("%input%", stateString)));
             		} else {
             			if (stateString.equals("TRUE")) {
             				if (!plugin.ignorePlayers.contains(target.getUniqueId())) {
-            					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgOtherIgnoreOn.replaceAll("%player%", target.getName())));
+            					sender.sendMessage(messageFormatting.parseMessage(msgOtherIgnoreOn.replaceAll("%player%", target.getName())));
         	                    plugin.ignorePlayers.add(target.getUniqueId());
             				} else {
-            					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgOtherAlreadyIgnored.replaceAll("%player%", target.getName())));
+            					sender.sendMessage(messageFormatting.parseMessage(msgOtherAlreadyIgnored.replaceAll("%player%", target.getName())));
             				}
             			} else {
-            				sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgOtherIgnoreOff.replaceAll("%player%", target.getName())));
+            				sender.sendMessage(messageFormatting.parseMessage(msgOtherIgnoreOff.replaceAll("%player%", target.getName())));
     	                    plugin.ignorePlayers.remove(target.getUniqueId());
     	                }
             		}
@@ -95,7 +97,7 @@ public class Commands implements CommandExecutor {
             case "reload":
             	if (!hasPermission(sender, "sleeper.reload")) break;
                 plugin.loadConfig();
-                sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgConfigReloaded));
+                sender.sendMessage(messageFormatting.parseMessage(msgConfigReloaded));
                 return true;
             }
             if (!isPlayer(sender)) return true;
@@ -145,12 +147,12 @@ public class Commands implements CommandExecutor {
                 plugin.getOnlineIgnorers().forEach(p -> player.sendMessage(ChatColor.GRAY + p.getDisplayName()));
                 break;
             default:
-                sender.sendMessage(ChatColor.translateAlternateColorCodes('&', playerHelpMsg(player)));
+                sender.sendMessage(messageFormatting.parseMessage(playerHelpMsg(player)));
                 break;
             }
             break;
         default:
-            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', playerHelpMsg(sender)));
+            sender.sendMessage(messageFormatting.parseMessage(playerHelpMsg(sender)));
             break;
         }
         return true;
@@ -158,7 +160,7 @@ public class Commands implements CommandExecutor {
     
     private boolean isPlayer(CommandSender sender) {
         if (!(sender instanceof Player)) {
-        	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', msgOnlyPlayers));
+        	sender.sendMessage(messageFormatting.parseMessage(msgOnlyPlayers));
             return false;
         }
         return true;
@@ -166,7 +168,7 @@ public class Commands implements CommandExecutor {
     
     private boolean hasPermission(CommandSender player, String permission) {
     	if (!player.hasPermission(permission)) {
-    		player.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.noPermission));
+    		player.sendMessage(messageFormatting.parseMessage(plugin.noPermission));
     		return false;
     	}
     	return true;

--- a/src/main/java/sleeper/main/EventHandlers.java
+++ b/src/main/java/sleeper/main/EventHandlers.java
@@ -18,11 +18,13 @@ public class EventHandlers implements Listener {
 
     Main plugin;
     Voting voting;
+    MessageFormatting messageFormatting;
 
-    public EventHandlers(Main plugin, Voting voting) {
+    public EventHandlers(Main plugin, Voting voting, MessageFormatting messageFormatting) {
         super();
         this.plugin = plugin;
         this.voting = voting;
+        this.messageFormatting = messageFormatting;
         dfrmt.setMaximumFractionDigits(2);
     }
 
@@ -50,7 +52,7 @@ public class EventHandlers implements Listener {
         int countNeeded =  (int) Math.ceil(wonline*(plugin.skipPercentage/100d));
         if (wsleeping > 0) plugin.sleepingWorlds.put(player.getWorld().getName(), wsleeping - 1);
         if (!plugin.recentlySkipped.contains(player.getWorld().getName())) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+            player.sendMessage(messageFormatting.parseMessage(
                     plugin.sleepInfo.replace("%percent%", dfrmt.format((wsleeping / wonline) * 100) + "%")
                             .replace("%count_needed%", dfrmt.format(countNeeded))
                             .replace("%count%", dfrmt.format(wsleeping))));
@@ -73,7 +75,7 @@ public class EventHandlers implements Listener {
             float wsleeping = plugin.sleepingWorlds.getOrDefault(player.getWorld().getName(), 0f);
             float wonline = plugin.playersOnline.getOrDefault(player.getWorld().getName(), 0f);
             int countNeeded =  (int) Math.ceil(wonline*(plugin.skipPercentage/100d));
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+            player.sendMessage(messageFormatting.parseMessage(
                     plugin.ignored.replace("%percent%", dfrmt.format((wsleeping / wonline) * 100) + "%")
                             .replace("%count_needed%", dfrmt.format(countNeeded))
                             .replace("%count%", dfrmt.format(wsleeping))));

--- a/src/main/java/sleeper/main/Main.java
+++ b/src/main/java/sleeper/main/Main.java
@@ -41,6 +41,7 @@ public class Main extends JavaPlugin {
     boolean broadcastNightSkip = true;
     int skipPercentage = 25;
     int skipSpeed = 100;
+    boolean sendSleepInfo = true; // as opposed to Broadcast, regulates whether SleepInfo should be sent at all?
     boolean broadcastSleepInfo = false;
     boolean delaySleep = false;
     long delaySeconds = 0;
@@ -124,6 +125,7 @@ public class Main extends JavaPlugin {
         }
         ignored = config.getString("Ignored");
         noPermission = config.getString("NoPermission");
+        sendSleepInfo = config.getBoolean("SendSleepInfo");
         broadcastSleepInfo = config.getBoolean("BroadcastSleepInfo");
         delaySeconds = config.getLong("DelaySeconds");
         delaySleep = config.getBoolean("DelaySleep");
@@ -199,13 +201,13 @@ public class Main extends JavaPlugin {
                                 ChatColor.YELLOW + "DEBUG: " + ChatColor.GRAY + "voting: " + voting.votingWorlds.toString());
                     }
                     // Sleepinfo message
-                    if (!broadcastSleepInfo) {
+                    if (!broadcastSleepInfo && sendSleepInfo) {
                         sendMessage(player, messageFormatting.parseMessage(
                                 sleepInfo.replace("%percent%", dfrmt.format(percentage) + "%")
                                         .replace("%count%", dfrmt.format(wsleeping))
                                         .replace("%count_needed%", dfrmt.format(countNeeded))
                                         .replace("%player%", player.getName())));
-                    } else { // Tell everyone in the world
+                    } else if (sendSleepInfo) { // Tell everyone in the world
                         for (Player players : world.getPlayers()) {
                             sendMessage(players, messageFormatting.parseMessage(
                                     sleepInfo.replace("%percent%", dfrmt.format(percentage) + "%")

--- a/src/main/java/sleeper/main/Main.java
+++ b/src/main/java/sleeper/main/Main.java
@@ -41,7 +41,6 @@ public class Main extends JavaPlugin {
     boolean broadcastNightSkip = true;
     int skipPercentage = 25;
     int skipSpeed = 100;
-    boolean sendSleepInfo = true; // as opposed to Broadcast, regulates whether SleepInfo should be sent at all?
     boolean broadcastSleepInfo = false;
     boolean delaySleep = false;
     long delaySeconds = 0;
@@ -125,7 +124,6 @@ public class Main extends JavaPlugin {
         }
         ignored = config.getString("Ignored");
         noPermission = config.getString("NoPermission");
-        sendSleepInfo = config.getBoolean("SendSleepInfo");
         broadcastSleepInfo = config.getBoolean("BroadcastSleepInfo");
         delaySeconds = config.getLong("DelaySeconds");
         delaySleep = config.getBoolean("DelaySleep");
@@ -201,13 +199,13 @@ public class Main extends JavaPlugin {
                                 ChatColor.YELLOW + "DEBUG: " + ChatColor.GRAY + "voting: " + voting.votingWorlds.toString());
                     }
                     // Sleepinfo message
-                    if (!broadcastSleepInfo && sendSleepInfo) {
+                    if (!broadcastSleepInfo) {
                         sendMessage(player, messageFormatting.parseMessage(
                                 sleepInfo.replace("%percent%", dfrmt.format(percentage) + "%")
                                         .replace("%count%", dfrmt.format(wsleeping))
                                         .replace("%count_needed%", dfrmt.format(countNeeded))
                                         .replace("%player%", player.getName())));
-                    } else if (sendSleepInfo) { // Tell everyone in the world
+                    } else { // Tell everyone in the world
                         for (Player players : world.getPlayers()) {
                             sendMessage(players, messageFormatting.parseMessage(
                                     sleepInfo.replace("%percent%", dfrmt.format(percentage) + "%")

--- a/src/main/java/sleeper/main/Main.java
+++ b/src/main/java/sleeper/main/Main.java
@@ -38,7 +38,6 @@ public class Main extends JavaPlugin {
 
     // Setting values
     boolean useAnimation = true;
-    boolean broadcastNightSkip = true;
     int skipPercentage = 25;
     int skipSpeed = 100;
     boolean broadcastSleepInfo = false;
@@ -112,7 +111,6 @@ public class Main extends JavaPlugin {
         reloadConfig();
         FileConfiguration config = this.getConfig();
         useAnimation = config.getBoolean("UseAnimation");
-        broadcastNightSkip = config.getBoolean("BroadcastNightSkip");
         skipPercentage = config.getInt("SkipPercentage");
         skipSpeed = config.getInt("SkipSpeed");
         sleepInfo = config.getString("SleepInfo");
@@ -232,16 +230,13 @@ public class Main extends JavaPlugin {
                             player.sendMessage(ChatColor.YELLOW + "DEBUG: " + ChatColor.GRAY + "Skipping...");
                         }
                         
-                        if (broadcastNightSkip)
-                        {
-                            String chosenMessage = nightSkip.get(random.nextInt(nightSkip.size()));
-                            for (Player players : world.getPlayers()) {
-                                sendMessage(players, messageFormatting.parseMessage(
-                                        chosenMessage.replace("%percent%", dfrmt.format(percentage) + "%")
-                                                .replace("%count%", dfrmt.format(wsleeping))
-                                                .replace("%count_needed%", dfrmt.format(countNeeded))
-                                                .replace("%player%", player.getName())));
-                            }
+                        String chosenMessage = nightSkip.get(random.nextInt(nightSkip.size()));
+                        for (Player players : world.getPlayers()) {
+                            sendMessage(players, messageFormatting.parseMessage(
+                                    chosenMessage.replace("%percent%", dfrmt.format(percentage) + "%")
+                                            .replace("%count%", dfrmt.format(wsleeping))
+                                            .replace("%count_needed%", dfrmt.format(countNeeded))
+                                            .replace("%player%", player.getName())));
                         }
                         
                         skipping.add(pWorld);

--- a/src/main/java/sleeper/main/Main.java
+++ b/src/main/java/sleeper/main/Main.java
@@ -200,14 +200,14 @@ public class Main extends JavaPlugin {
                     }
                     // Sleepinfo message
                     if (!broadcastSleepInfo) {
-                        sendMessage(player, ChatColor.translateAlternateColorCodes('&',
+                        sendMessage(player, messageFormatting.parseMessage(
                                 sleepInfo.replace("%percent%", dfrmt.format(percentage) + "%")
                                         .replace("%count%", dfrmt.format(wsleeping))
                                         .replace("%count_needed%", dfrmt.format(countNeeded))
                                         .replace("%player%", player.getName())));
                     } else { // Tell everyone in the world
                         for (Player players : world.getPlayers()) {
-                            sendMessage(players, ChatColor.translateAlternateColorCodes('&',
+                            sendMessage(players, messageFormatting.parseMessage(
                                     sleepInfo.replace("%percent%", dfrmt.format(percentage) + "%")
                                             .replace("%count%", dfrmt.format(wsleeping))
                                             .replace("%count_needed%", dfrmt.format(countNeeded))
@@ -236,7 +236,7 @@ public class Main extends JavaPlugin {
                         {
                             String chosenMessage = nightSkip.get(random.nextInt(nightSkip.size()));
                             for (Player players : world.getPlayers()) {
-                                sendMessage(players, ChatColor.translateAlternateColorCodes('&',
+                                sendMessage(players, messageFormatting.parseMessage(
                                         chosenMessage.replace("%percent%", dfrmt.format(percentage) + "%")
                                                 .replace("%count%", dfrmt.format(wsleeping))
                                                 .replace("%count_needed%", dfrmt.format(countNeeded))

--- a/src/main/java/sleeper/main/MessageFormatting.java
+++ b/src/main/java/sleeper/main/MessageFormatting.java
@@ -39,7 +39,7 @@ public class MessageFormatting {
     
     public void loadConfig(FileConfiguration config) {
     	String configFormattingType = config.getString("FormattingType");
-        if (allowedTypes.contains(configFormattingType.toUpperCase()))
+        if (configFormattingType != null && allowedTypes.contains(configFormattingType.toUpperCase()))
             formattingType = configFormattingType.toUpperCase();
         else
         {

--- a/src/main/java/sleeper/main/MessageFormatting.java
+++ b/src/main/java/sleeper/main/MessageFormatting.java
@@ -16,7 +16,7 @@ public class MessageFormatting {
         this.plugin = plugin;
     }
     
-    Set<String> allowedTypes = Set.of("LEGACY_AMPERSAND", "LEGACY_SECTION", "MINIMESSAGE");
+    Set<String> allowedTypes = Set.of("MINECRAFT", "MINIMESSAGE");
     
     // Setting value
     String formattingType = "MINIMESSAGE";
@@ -25,10 +25,8 @@ public class MessageFormatting {
     
     public String parseMessage(String message) {
         switch (formattingType) {
-            case "LEGACY_AMPERSAND":
+            case "MINECRAFT":
                 return ChatColor.translateAlternateColorCodes('&', message);
-            case "LEGACY_SECTION":
-                return ChatColor.translateAlternateColorCodes('§', message);
             case "MINIMESSAGE":
                 Component component = miniMessage.deserialize(message);
                 return LegacyComponentSerializer.legacySection().serialize(component);

--- a/src/main/java/sleeper/main/MessageFormatting.java
+++ b/src/main/java/sleeper/main/MessageFormatting.java
@@ -19,7 +19,7 @@ public class MessageFormatting {
     Set<String> allowedTypes = Set.of("MINECRAFT", "MINIMESSAGE");
     
     // Setting value
-    String formattingType = "MINIMESSAGE";
+    String formattingType = "MINECRAFT";
     
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
     

--- a/src/main/java/sleeper/main/MessageFormatting.java
+++ b/src/main/java/sleeper/main/MessageFormatting.java
@@ -1,0 +1,49 @@
+package sleeper.main;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.Set;
+
+public class MessageFormatting {
+    
+    Main plugin;
+    
+    public MessageFormatting(Main plugin) {
+        this.plugin = plugin;
+    }
+    
+    Set<String> allowedTypes = Set.of("LEGACY_AMPERSAND", "LEGACY_SECTION", "MINIMESSAGE");
+    
+    // Setting value
+    String formattingType = "MINIMESSAGE";
+    
+    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+    
+    public String parseMessage(String message) {
+        switch (formattingType) {
+            case "LEGACY_AMPERSAND":
+                return ChatColor.translateAlternateColorCodes('&', message);
+            case "LEGACY_SECTION":
+                return ChatColor.translateAlternateColorCodes('§', message);
+            case "MINIMESSAGE":
+                Component component = miniMessage.deserialize(message);
+                return LegacyComponentSerializer.legacySection().serialize(component);
+            default:
+                return message;
+        }
+    }
+    
+    public void loadConfig(FileConfiguration config) {
+    	String configFormattingType = config.getString("FormattingType");
+        if (allowedTypes.contains(configFormattingType.toUpperCase()))
+            formattingType = configFormattingType.toUpperCase();
+        else
+        {
+            plugin.getLogger().warning("FormattingType value is not appropriate! Reset to default.");
+        }
+    }
+}

--- a/src/main/java/sleeper/main/Voting.java
+++ b/src/main/java/sleeper/main/Voting.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map.Entry;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
@@ -17,11 +16,14 @@ import net.md_5.bungee.api.chat.TextComponent;
 public class Voting {
 
     Main plugin;
+    
+    MessageFormatting messageFormatting;
 
     DecimalFormat dfrmt = new DecimalFormat();
     
-    public Voting(Main plugin) {
+    public Voting(Main plugin, MessageFormatting messageFormatting) {
         this.plugin = plugin;
+        this.messageFormatting = messageFormatting;
         dfrmt.setMaximumFractionDigits(2);
     }
     
@@ -73,54 +75,54 @@ public class Voting {
 
     public void voteYes(Player player) {
         if (!player.hasPermission("sleeper.vote")) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.noPermission));
+            player.sendMessage(messageFormatting.parseMessage(plugin.noPermission));
             return;
         }
         if (!useVote) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', voteNotEnabled));
+            player.sendMessage(messageFormatting.parseMessage(voteNotEnabled));
             return;
         }
         if (voteStarts && !votingWorlds.contains(player.getWorld().getName())) {
             startVote(player);
         }
         if (!votingWorlds.contains(player.getWorld().getName())) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', noVote));
+            player.sendMessage(messageFormatting.parseMessage(noVote));
             return;
         }
         if (yesVotes.containsKey(player.getName())) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', alreadyYes));
+            player.sendMessage(messageFormatting.parseMessage(alreadyYes));
             return;
         }
         noVotes.remove(player.getName());
         yesVotes.put(player.getName(), player.getWorld().getName());
-        player.sendMessage(ChatColor.translateAlternateColorCodes('&', votedYes));
+        player.sendMessage(messageFormatting.parseMessage(votedYes));
         plugin.onlinePlayers(player.getWorld().getName());
         showVotes(player);
     }
 
     public void voteNo(Player player) {
         if (!player.hasPermission("sleeper.vote")) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.noPermission));
+            player.sendMessage(messageFormatting.parseMessage(plugin.noPermission));
             return;
         }
         if (!useVote) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', voteNotEnabled));
+            player.sendMessage(messageFormatting.parseMessage(voteNotEnabled));
             return;
         }
         if (voteStarts && !votingWorlds.contains(player.getWorld().getName())) {
             startVote(player);
         }
         if (!votingWorlds.contains(player.getWorld().getName())) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', noVote));
+            player.sendMessage(messageFormatting.parseMessage(noVote));
             return;
         }
         if (noVotes.containsKey(player.getName())) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', alreadyNo));
+            player.sendMessage(messageFormatting.parseMessage(alreadyNo));
             return;
         }
         yesVotes.remove(player.getName());
         noVotes.put(player.getName(), player.getWorld().getName());
-        player.sendMessage(ChatColor.translateAlternateColorCodes('&', votedNo));
+        player.sendMessage(messageFormatting.parseMessage(votedNo));
         plugin.onlinePlayers(player.getWorld().getName());
         showVotes(player);
     }
@@ -143,22 +145,22 @@ public class Voting {
 
     public void sendVoteMsg(Player player) {
         if (!useVote) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', voteNotEnabled));
+            player.sendMessage(messageFormatting.parseMessage(voteNotEnabled));
             return;
         }
-        player.sendMessage(ChatColor.translateAlternateColorCodes('&', voteTitle));
+        player.sendMessage(messageFormatting.parseMessage(voteTitle));
         TextComponent yesMessage = new TextComponent(
-                TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', voteYes)));
+                TextComponent.fromLegacyText(messageFormatting.parseMessage(voteYes)));
         yesMessage.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/sleep yes"));
         player.spigot().sendMessage(yesMessage);
         TextComponent noMessage = new TextComponent(
-                TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', voteNo)));
+                TextComponent.fromLegacyText(messageFormatting.parseMessage(voteNo)));
         noMessage.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/sleep no"));
         player.spigot().sendMessage(noMessage);
     }
 
     public void showVotes(Player player) {
-        player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+        player.sendMessage(messageFormatting.parseMessage(
                 listVotes.replace("%yes%", dfrmt.format(countYes(player.getWorld().getName()))).replace("%no%",
                         dfrmt.format(countNo(player.getWorld().getName())))));
     }
@@ -190,7 +192,7 @@ public class Voting {
             long time = world.getTime();
             if (plugin.skipping.contains(worldName)) continue;
             if (bossbarVoteCount) {
-                plugin.bar.setTitle(ChatColor.translateAlternateColorCodes('&',
+                plugin.bar.setTitle(messageFormatting.parseMessage(
                         listVotes.replace("%yes%", dfrmt.format(countYes(worldName))).replace("%no%",
                                 dfrmt.format(countNo(worldName)))));
                 for (Player player : world.getPlayers()) {
@@ -204,7 +206,7 @@ public class Voting {
                 if (timeLeft <= 0) {
                     votingWorldTimes.remove(worldName);
                     world.getPlayers().forEach(
-                            player -> plugin.sendMessage(player, ChatColor.translateAlternateColorCodes('&', voteTimedOut)));
+                            player -> plugin.sendMessage(player, messageFormatting.parseMessage(voteTimedOut)));
                     endVote(worldName);
                 }
                 votingWorldTimes.replace(worldName, timeLeft);
@@ -221,7 +223,7 @@ public class Voting {
                     plugin.skipping.add(worldName);
                     plugin.recentlySkipped.add(worldName);
                     world.getPlayers().forEach(
-                            player -> plugin.sendMessage(player, ChatColor.translateAlternateColorCodes('&', skipByVote)));
+                            player -> plugin.sendMessage(player, messageFormatting.parseMessage(skipByVote)));
                     plugin.getLogger().info("Skipping night by vote in " + worldName);
                 }
             }

--- a/src/main/java/sleeper/main/Voting.java
+++ b/src/main/java/sleeper/main/Voting.java
@@ -4,7 +4,6 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -12,7 +11,6 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
 import net.md_5.bungee.api.chat.ClickEvent;
-import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 
 public class Voting {
@@ -35,17 +33,13 @@ public class Voting {
     HashMap<String, String> yesVotes = new HashMap<>();
     HashMap<String, String> noVotes = new HashMap<>();
     
-    Set<String> allowedVoteCountModes = Set.of("none", "bossbar", "actionbar");
-    
-    private int tickCounter = 0;
-    
     // Voting setting values
     boolean useVote = false;
     int yesMultiplier = 1;
     int noMultiplier = 1;
     int skipVotePercent = 50;
     boolean blockBedsAfterVoting = false;
-    String sendVoteCountMode = "none";
+    boolean bossbarVoteCount = true;
     boolean sendVotesOnStart = true;
     boolean voteStarts = false;
     int maxVoteTime = 60;
@@ -197,22 +191,13 @@ public class Voting {
             World world = Bukkit.getWorld(worldName);
             long time = world.getTime();
             if (plugin.skipping.contains(worldName)) continue;
-            if (sendVoteCountMode.equals("bossbar")) {
+            if (bossbarVoteCount) {
                 plugin.bar.setTitle(messageFormatting.parseMessage(
                         listVotes.replace("%yes%", dfrmt.format(countYes(worldName))).replace("%no%",
                                 dfrmt.format(countNo(worldName)))));
                 for (Player player : world.getPlayers()) {
                     if (plugin.bar.getPlayers().contains(player)) continue;
                     plugin.bar.addPlayer(player);
-                }
-            }
-            else if (sendVoteCountMode.equals("actionbar")) {
-                tickCounter++;
-                if (tickCounter % 20 != 0) return;
-                for (Player player : world.getPlayers()) {
-                    player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(messageFormatting.parseMessage(
-                        listVotes.replace("%yes%", dfrmt.format(countYes(worldName))).replace("%no%",
-                                dfrmt.format(countNo(worldName))))));
                 }
             }
             if (votingWorldTimes.containsKey(worldName)) {
@@ -262,21 +247,12 @@ public class Voting {
         skipByVote = config.getString("SkipByVote");
         voteNotEnabled = config.getString("VoteNotEnabled");
         blockBedsAfterVoting = config.getBoolean("BlockBedsAfterVoting");
+        bossbarVoteCount = config.getBoolean("BossbarVoteCount");
         sendVotesOnStart = config.getBoolean("SendVotesOnStart");
         voteStarts = config.getBoolean("StartWithoutSleep");
         maxVoteTime = config.getInt("MaxVoteTime");
         limitedVoteTime = config.getBoolean("LimitedVoteTime");
         voteTimedOut = config.getString("VoteTimedOut");
-        
-        String configVoteCountMode = config.getString("VoteCountMode");
-        if (configVoteCountMode != null && allowedVoteCountModes.contains(configVoteCountMode.toLowerCase()))
-        {
-            sendVoteCountMode = configVoteCountMode.toLowerCase();
-        }
-        else
-        {
-            plugin.getLogger().warning("VoteCountMode value is not appropriate! Reset to default.");
-        }
     }
     
 }

--- a/src/main/java/sleeper/main/Voting.java
+++ b/src/main/java/sleeper/main/Voting.java
@@ -4,6 +4,7 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -11,6 +12,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
 import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 
 public class Voting {
@@ -33,13 +35,17 @@ public class Voting {
     HashMap<String, String> yesVotes = new HashMap<>();
     HashMap<String, String> noVotes = new HashMap<>();
     
+    Set<String> allowedVoteCountModes = Set.of("none", "bossbar", "actionbar");
+    
+    private int tickCounter = 0;
+    
     // Voting setting values
     boolean useVote = false;
     int yesMultiplier = 1;
     int noMultiplier = 1;
     int skipVotePercent = 50;
     boolean blockBedsAfterVoting = false;
-    boolean bossbarVoteCount = true;
+    String sendVoteCountMode = "none";
     boolean sendVotesOnStart = true;
     boolean voteStarts = false;
     int maxVoteTime = 60;
@@ -191,13 +197,22 @@ public class Voting {
             World world = Bukkit.getWorld(worldName);
             long time = world.getTime();
             if (plugin.skipping.contains(worldName)) continue;
-            if (bossbarVoteCount) {
+            if (sendVoteCountMode.equals("bossbar")) {
                 plugin.bar.setTitle(messageFormatting.parseMessage(
                         listVotes.replace("%yes%", dfrmt.format(countYes(worldName))).replace("%no%",
                                 dfrmt.format(countNo(worldName)))));
                 for (Player player : world.getPlayers()) {
                     if (plugin.bar.getPlayers().contains(player)) continue;
                     plugin.bar.addPlayer(player);
+                }
+            }
+            else if (sendVoteCountMode.equals("actionbar")) {
+                tickCounter++;
+                if (tickCounter % 20 != 0) return;
+                for (Player player : world.getPlayers()) {
+                    player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(messageFormatting.parseMessage(
+                        listVotes.replace("%yes%", dfrmt.format(countYes(worldName))).replace("%no%",
+                                dfrmt.format(countNo(worldName))))));
                 }
             }
             if (votingWorldTimes.containsKey(worldName)) {
@@ -247,12 +262,21 @@ public class Voting {
         skipByVote = config.getString("SkipByVote");
         voteNotEnabled = config.getString("VoteNotEnabled");
         blockBedsAfterVoting = config.getBoolean("BlockBedsAfterVoting");
-        bossbarVoteCount = config.getBoolean("BossbarVoteCount");
         sendVotesOnStart = config.getBoolean("SendVotesOnStart");
         voteStarts = config.getBoolean("StartWithoutSleep");
         maxVoteTime = config.getInt("MaxVoteTime");
         limitedVoteTime = config.getBoolean("LimitedVoteTime");
         voteTimedOut = config.getString("VoteTimedOut");
+        
+        String configVoteCountMode = config.getString("VoteCountMode");
+        if (configVoteCountMode != null && allowedVoteCountModes.contains(configVoteCountMode.toLowerCase()))
+        {
+            sendVoteCountMode = configVoteCountMode.toLowerCase();
+        }
+        else
+        {
+            plugin.getLogger().warning("VoteCountMode value is not appropriate! Reset to default.");
+        }
     }
     
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,8 +25,7 @@ YesMultiplier: 1
 NoMultiplier: 1
 SkipVotePercent: 50
 BlockBedsAfterVoting: false
-# Available Options: None, BossBar, ActionBar
-VoteCountMode: "BossBar"
+BossbarVoteCount: true
 SendVotesOnStart: true
 StartWithoutSleep: false
 MaxVoteTime: 60

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,7 +18,6 @@ DelaySeconds: 4
 
 # Other settings
 BroadcastNightSkip: false
-SendSleepInfo: true
 BroadcastSleepInfo: false
 
 # Voting system, a night is skipped based on yes votes minus no votes

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,12 @@
 # Plugin settings
 CheckForUpdates: true
 
+# Available serializers:
+# legacy_ampersand - "&c&lExample Text"
+# legacy_section - "§c§lExample Text"
+# minimessage - "<red><bold>Example Text"
+FormattingType: "legacy_ampersand"
+
 # Main settings
 UseAnimation: true
 SkipPercentage: 25
@@ -11,6 +17,7 @@ DelaySleep: false
 DelaySeconds: 4
 
 # Other settings
+BroadcastNightSkip: false
 BroadcastSleepInfo: false
 
 # Voting system, a night is skipped based on yes votes minus no votes

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,7 @@ DelaySeconds: 4
 
 # Other settings
 BroadcastNightSkip: false
+SendSleepInfo: true
 BroadcastSleepInfo: false
 
 # Voting system, a night is skipped based on yes votes minus no votes

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,10 +4,9 @@
 CheckForUpdates: true
 
 # Available serializers:
-# legacy_ampersand - "&c&lExample Text"
-# legacy_section - "§c§lExample Text"
+# minecraft - "&c&lExample Text"
 # minimessage - "<red><bold>Example Text"
-FormattingType: "legacy_ampersand"
+FormattingType: "minecraft"
 
 # Main settings
 UseAnimation: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,7 +27,7 @@ YesMultiplier: 1
 NoMultiplier: 1
 SkipVotePercent: 50
 BlockBedsAfterVoting: false
-BossbarVoteCount: true
+VoteCountMode: "BossBar"
 SendVotesOnStart: true
 StartWithoutSleep: false
 MaxVoteTime: 60

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,7 +17,6 @@ DelaySleep: false
 DelaySeconds: 4
 
 # Other settings
-BroadcastNightSkip: false
 BroadcastSleepInfo: false
 
 # Voting system, a night is skipped based on yes votes minus no votes

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,6 +27,7 @@ YesMultiplier: 1
 NoMultiplier: 1
 SkipVotePercent: 50
 BlockBedsAfterVoting: false
+# Available Options: None, BossBar, ActionBar
 VoteCountMode: "BossBar"
 SendVotesOnStart: true
 StartWithoutSleep: false


### PR DESCRIPTION
# ✨ What Does This PR Add?
- Message formatting selection via config:
  ```yaml
  # Available serializers:
  # minecraft - "&c&lExample Text"
  # minimessage - "<red><bold>Example Text"
  FormattingType: "legacy_ampersand"
  ```

# 🔧 What Does This PR Change?
- All message formatting using `ChatColor.translateAlternateColorCodes` has been replaced with a centralized `MessageFormatting` class, allowing support for multiple formatting styles across the plugin.
- New `MessageFormatting` utility is introduced to handle formatting logic based on the `FormattingType` config value.