### PR TITLE
Replace %percent_needed% placeholder in onBedExit

### DIFF
--- a/src/main/java/sleeper/main/EventHandlers.java
+++ b/src/main/java/sleeper/main/EventHandlers.java
@@ -2,7 +2,6 @@ package sleeper.main;
 
 import java.text.DecimalFormat;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -55,6 +54,7 @@ public class EventHandlers implements Listener {
         if (!plugin.recentlySkipped.contains(worldName)) {
             messageHandler.sendMessage(player, plugin.sleepInfo
                     .replace("%percent%", dfrmt.format((wsleeping / wonline) * 100) + "%")
+                    .replace("%percent_needed%", dfrmt.format(plugin.skipPercentage) + "%")
                     .replace("%count_needed%", dfrmt.format(countNeeded)).replace("%count%", dfrmt.format(wsleeping)));
         }
         plugin.getWorldSleepers(worldName).remove(player.getUniqueId());


### PR DESCRIPTION
This placeholder is used in the default value of SleepInfo and as such should definitely be replaced here, and not just in the sleep() usage of SleepInfo

org.bukkit.Bukkit import is unused in EventHandlers.java and was therefore removed

fixes #37 